### PR TITLE
Make editor it's own executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,56 +14,75 @@ add_subdirectory(include)
 add_subdirectory(src)
 
 #Add and Configure Engine executable
-add_executable(uwuEngine ${HEADERS} ${SOURCE})
-set_property(TARGET uwuEngine PROPERTY CXX_STANDARD 17)
+add_executable(Umbra ${HEADERS} ${SOURCE})
+add_executable(uwuEditor ${HEADERS} ${SOURCE})
+
+target_compile_definitions(uwuEditor PUBLIC _Editor)
+set_property(TARGET Umbra uwuEditor PROPERTY CXX_STANDARD 17)
+
 if (MSVC)
-    target_compile_definitions(uwuEngine PUBLIC _MSVC)
+    target_compile_definitions(Umbra PUBLIC _MSVC)
+    target_compile_definitions(uwuEditor PUBLIC _MSVC)
 else ()
-    add_compile_options(uwuEngine -g)
-    target_compile_definitions(uwuEngine PUBLIC _GLIBCXX_DEBUG)
+    add_compile_options(Umbra -g)
+    add_compile_options(uwuEditor -g)
+    target_compile_definitions(Umbra PUBLIC _GLIBCXX_DEBUG)
+    target_compile_definitions(uwuEditor PUBLIC _GLIBCXX_DEBUG)
 endif()
 
-target_include_directories(uwuEngine PUBLIC ${FMOD_INCLUDE_DIR})
+target_include_directories(Umbra PUBLIC ${FMOD_INCLUDE_DIR})
+target_include_directories(uwuEditor PUBLIC ${FMOD_INCLUDE_DIR})
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     message("we in debug mode")
-    target_compile_definitions(uwuEngine PUBLIC _DEBUG)
+    target_compile_definitions(Umbra PUBLIC _DEBUG)
+    target_compile_definitions(uwuEditor PUBLIC _DEBUG)
 endif()
 
+#Populate library list
+set(UWU_LIBS
+    ${FMOD_LIBRARY}
+    ${FSBANK_LIBRARY}
+    ${FMOD_STUDIO_LIBRARY}
+    libglew_static
+    glfw
+    GLM
+    L_IMGUI
+    MAGIC_ENUM
+    RAPID_JSON
+    RECTPACK2D
+    STB
+    L_SPINE_C
+)
+#Extend compiler/OS specific libs
 if (MSVC)
-    target_link_libraries(uwuEngine
-            opengl32
-            glu32
-            )
+    set(UWU_LIBS
+        ${UWU_LIBS}
+        opengl32
+        glu32
+    )
 else ()
-    target_link_libraries(uwuEngine
-            OpenGL
-            GLX
-            stdc++fs
-            )
+    set(UWU_LIBS
+        ${UWU_LIBS}
+        OpenGL
+        GLX
+        stdc++fs
+    )
 endif ()
-
-target_link_libraries(uwuEngine
-        ${FMOD_LIBRARY}
-        ${FSBANK_LIBRARY}
-        ${FMOD_STUDIO_LIBRARY}
-        libglew_static
-        glfw
-        GLM
-        L_IMGUI
-        MAGIC_ENUM
-        RAPID_JSON
-        RECTPACK2D
-        STB
-        L_SPINE_C
-        )
+#Link targets with libraries
+target_link_libraries(Umbra ${UWU_LIBS})
+target_link_libraries(uwuEditor ${UWU_LIBS})
 
 # Copy FMOD dll
 if (WIN32)
-add_custom_command(TARGET uwuEngine POST_BUILD
+add_custom_command(TARGET Umbra POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${FMOD_DLL}
-        $<TARGET_FILE_DIR:uwuEngine>)
+        $<TARGET_FILE_DIR:Umbra>)
+add_custom_command(TARGET uwuEditor POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${FMOD_DLL}
+        $<TARGET_FILE_DIR:uwuEditor>)
 endif ()
 
 # Copy Data folder

--- a/src/Scenes/BrayanSBOX.cpp
+++ b/src/Scenes/BrayanSBOX.cpp
@@ -49,11 +49,15 @@ void GameStateMachine::Enter_BrayanSBOX()
     }
   }
 
+  #ifdef _Editor
+  DynamicCamera::Deactivate();
+  Lighting::Deactivate();
+  #else
   DynamicCamera::Activate();
   Lighting::Activate();
-  TextureAtlaser::LoadAtlasPage();
-
   SoundInterface::playSound("music_calm1", true);
+  #endif
+  TextureAtlaser::LoadAtlasPage();
 }
 
 
@@ -71,15 +75,11 @@ void GameStateMachine::Update_BrayanSBOX(float dt)
       LightingComponentManager::SetShininess(i, 16.0f);
     }
   }
-#ifndef _DEBUG
-  DynamicCamera::SetTrackingPos(glm::vec4(glm::vec2(TransformComponentManager::GetTranslation(PlayerData::GetPlayerID())) + glm::vec2{ 0, 100 }, Camera::GetCameraPosition().z, 1));
-  DynamicCamera::SetTrackingSpeed(2);
-  DynamicCamera::SetInnerBounds(100, 100, { 0, 100 });
-#else
+#ifdef _Editor
   static bool dynamic = false;
   if (
-  (InputManager::KeyHeld(GLFW_KEY_LEFT_CONTROL) || InputManager::KeyHeld(GLFW_KEY_RIGHT_CONTROL)) && 
-  InputManager::KeyPressed('C'))
+    (InputManager::KeyHeld(GLFW_KEY_LEFT_CONTROL) || InputManager::KeyHeld(GLFW_KEY_RIGHT_CONTROL)) &&
+    InputManager::KeyPressed('C'))
   {
     dynamic = !dynamic;
   }
@@ -95,6 +95,11 @@ void GameStateMachine::Update_BrayanSBOX(float dt)
   {
     DynamicCamera::Deactivate();
   }
+
+#else
+  DynamicCamera::SetTrackingPos(glm::vec4(glm::vec2(TransformComponentManager::GetTranslation(PlayerData::GetPlayerID())) + glm::vec2{ 0, 100 }, Camera::GetCameraPosition().z, 1));
+  DynamicCamera::SetTrackingSpeed(2);
+  DynamicCamera::SetInnerBounds(100, 100, { 0, 100 });
 #endif
 
   //if (InputManager::KeyPressed('v'))
@@ -137,8 +142,4 @@ void GameStateMachine::Exit_BrayanSBOX()
   SoundInterface::stopAllSounds();
   EntityManager::DestroyAll();
   TextureAtlaser::ClearData();
-
-  #ifdef _DEBUG_
-  Editor::Stop();
-#endif
 }


### PR DESCRIPTION
Now Editor have it's own executable instead of being the "Debug Mode" of uwu engine. It shares the same source file, library and assets with the main game.
![image](https://user-images.githubusercontent.com/11523007/72284210-4343d500-35f5-11ea-8e4e-76de94de44a6.png)

### Introducing the "_Editor" flag
Now when you are building the uwuEditor executable, "_Editor" flag will be enabled and all the editor exclusive codes should be included in the _Editor flag.
![image](https://user-images.githubusercontent.com/11523007/72284404-bfd6b380-35f5-11ea-8c5f-adb24d9c8d45.png)
